### PR TITLE
9.8.60 verbose |  Add tcp_seg pool counter

### DIFF
--- a/src/stats/stats_reader.cpp
+++ b/src/stats/stats_reader.cpp
@@ -247,6 +247,7 @@ void update_delta_ring_stat(ring_stats_t* p_curr_ring_stats, ring_stats_t* p_pre
 			p_prev_ring_stats->simple.n_tx_dev_mem_allocated = p_curr_ring_stats->simple.n_tx_dev_mem_allocated;
 			p_prev_ring_stats->simple.n_tx_dev_mem_byte_count = (p_curr_ring_stats->simple.n_tx_dev_mem_byte_count - p_prev_ring_stats->simple.n_tx_dev_mem_byte_count) / delay;
 			p_prev_ring_stats->simple.n_tx_dev_mem_pkt_count = (p_curr_ring_stats->simple.n_tx_dev_mem_pkt_count - p_prev_ring_stats->simple.n_tx_dev_mem_pkt_count) / delay;
+			p_prev_ring_stats->simple.n_tx_dropped_wqes = (p_curr_ring_stats->simple.n_tx_dropped_wqes - p_prev_ring_stats->simple.n_tx_dropped_wqes) / delay;
 			p_prev_ring_stats->simple.n_tx_dev_mem_oob = (p_curr_ring_stats->simple.n_tx_dev_mem_oob - p_prev_ring_stats->simple.n_tx_dev_mem_oob) / delay;
 		}
 	}
@@ -324,6 +325,9 @@ void print_ring_stats(ring_instance_block_t* p_ring_inst_arr)
 				if (p_ring_stats->simple.n_tx_dev_mem_allocated) {
 					printf(FORMAT_STATS_32bit, "Dev Mem Alloc:", p_ring_stats->simple.n_tx_dev_mem_allocated);
 					printf(FORMAT_RING_DM_STATS, "Dev Mem Stats:", p_ring_stats->simple.n_tx_dev_mem_byte_count/BYTES_TRAFFIC_UNIT,  p_ring_stats->simple.n_tx_dev_mem_pkt_count, p_ring_stats->simple.n_tx_dev_mem_oob, post_fix);
+				}
+				if (p_ring_stats->simple.n_tx_dropped_wqes) {
+					printf(FORMAT_STATS_64bit, "TX Dropped Send Reqs:", (unsigned long long int)p_ring_stats->simple.n_tx_dropped_wqes, post_fix);
 				}
 			}
 		}
@@ -1380,6 +1384,7 @@ void zero_ring_stats(ring_stats_t* p_ring_stats)
 		p_ring_stats->simple.n_rx_interrupt_requests = 0;
 		p_ring_stats->simple.n_tx_dev_mem_byte_count = 0;
 		p_ring_stats->simple.n_tx_dev_mem_pkt_count = 0;
+		p_ring_stats->simple.n_tx_dropped_wqes = 0;
 		p_ring_stats->simple.n_tx_dev_mem_oob = 0;
 	}
 }

--- a/src/vma/dev/ring_simple.cpp
+++ b/src/vma/dev/ring_simple.cpp
@@ -648,6 +648,7 @@ inline int ring_simple::send_buffer(vma_ibv_send_wr* p_send_wqe, vma_wr_tx_packe
 			mem_buf_desc_t* p_mem_buf_desc = (mem_buf_desc_t*)(p_send_wqe->wr_id);
 			p_mem_buf_desc->p_next_desc = NULL;
 		}
+		++m_p_ring_stat->simple.n_tx_dropped_wqes;
 	}
 	return ret;
 }

--- a/src/vma/sock/sockinfo_tcp.cpp
+++ b/src/vma/sock/sockinfo_tcp.cpp
@@ -4717,6 +4717,7 @@ tcp_seg_pool::tcp_seg_pool(int size) {
 		m_tcp_segs_array[i].next = &m_tcp_segs_array[i + 1];
 	}
 	m_p_head = &m_tcp_segs_array[0];
+	g_global_stats.n_tcp_seg_pool_size = size;
 }
 
 tcp_seg_pool::~tcp_seg_pool() {
@@ -4746,6 +4747,7 @@ tcp_seg * tcp_seg_pool::get_tcp_segs(int amount) {
 	}
 	prev->next = NULL;
 	m_p_head = next;
+	g_global_stats.n_tcp_seg_pool_size -= amount;
 	unlock();
 	return head;
 }
@@ -4755,13 +4757,16 @@ void tcp_seg_pool::put_tcp_segs(tcp_seg * seg_list) {
 	if (unlikely(!seg_list))
 		return;
 
+	int i = 1;
 	while (next->next) {
 		next = next->next;
+		i++;
 	}
 
 	lock();
 	next->next = m_p_head;
 	m_p_head = seg_list;
+	g_global_stats.n_tcp_seg_pool_size += i;
 	unlock();
 }
 

--- a/src/vma/util/vma_stats.h
+++ b/src/vma/util/vma_stats.h
@@ -302,6 +302,7 @@ typedef struct {
 	uint32_t    n_socket_objs;
 	uint32_t    n_tcp_socket_objs;
 	uint32_t    n_tcp_socket_objs_max;
+	uint32_t    n_tcp_seg_pool_size;
 } global_stats_t;
 extern global_stats_t g_global_stats;
 

--- a/src/vma/util/vma_stats.h
+++ b/src/vma/util/vma_stats.h
@@ -263,6 +263,7 @@ typedef struct {
 			uint64_t    n_rx_interrupt_received;
 			uint32_t    n_rx_cq_moderation_count;
 			uint32_t    n_rx_cq_moderation_period;
+			uint64_t    n_tx_dropped_wqes;
 			uint64_t    n_tx_dev_mem_pkt_count;
 			uint64_t    n_tx_dev_mem_byte_count;
 			uint64_t    n_tx_dev_mem_oob;


### PR DESCRIPTION
 Add tcp_seg pool counter
Add n_tcp_seg_pool_size to monitor global tcp_seg pool size.


## Change type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Check list
- [ ] Code follows the style de facto guidelines of this project
- [ ] Comments have been inserted in hard to understand places
- [ ] Documentation has been updated (if necessary)
- [ ] Test has been added (if possible)

